### PR TITLE
Enhancement: Update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # authomatic-redis
-[![Build Status](https://travis-ci.com/wearereasonablepeople/authomatic-redis.svg?token=yQTBKvDF8NXw5WvCpzqf&branch=master)](https://travis-ci.com/wearereasonablepeople/authomatic-redis)
+[![Build Status](https://travis-ci.org/wearereasonablepeople/authomatic-redis.svg?branch=master)](https://travis-ci.org/wearereasonablepeople/authomatic-redis)
 [![codecov](https://codecov.io/gh/wearereasonablepeople/authomatic-redis/branch/master/graph/badge.svg?token=Bh9Dku3el1)](https://codecov.io/gh/wearereasonablepeople/authomatic-redis)
 [![Maintainability](https://api.codeclimate.com/v1/badges/de17d1c089d4120b8a1f/maintainability)](https://codeclimate.com/github/wearereasonablepeople/authomatic-redis/maintainability)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authomatic-redis",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A redis store for Authomatic",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently, the badge points to travis-ci.com, but since we change this to a public repo, that does not work.

Closes #12 ;)